### PR TITLE
chore: replace any with explicit types

### DIFF
--- a/src/ai/flows/enrich-product-data.ts
+++ b/src/ai/flows/enrich-product-data.ts
@@ -103,9 +103,10 @@ const enrichProductDataFlow = ai.defineFlow(
       let parsedJson;
       try {
         parsedJson = JSON.parse(jsonString);
-      } catch(e: any) {
-          console.error("Failed to parse JSON from AI output. JSON string:", jsonString, "Error:", e.message);
-          return { error: `Fehler beim Parsen der AI-Antwort: ${e.message}` };
+      } catch(e: unknown) {
+          const message = e instanceof Error ? e.message : String(e);
+          console.error("Failed to parse JSON from AI output. JSON string:", jsonString, "Error:", message);
+          return { error: `Fehler beim Parsen der AI-Antwort: ${message}` };
       }
 
       const validationResult = EnrichedProductSchema.safeParse(parsedJson);
@@ -117,9 +118,9 @@ const enrichProductDataFlow = ai.defineFlow(
 
       return { product: validationResult.data };
 
-    } catch (e: any) {
+    } catch (e: unknown) {
         console.error("Critical error in enrichProductDataFlow:", e);
-        if (e.message && (e.message.includes('503') || e.message.includes('overloaded'))) {
+        if (e instanceof Error && e.message && (e.message.includes('503') || e.message.includes('overloaded'))) {
             return { error: "Der KI-Dienst ist derzeit ausgelastet oder nicht verfügbar. Bitte versuchen Sie es in ein paar Augenblicken erneut." };
         }
         return { error: "Beim Anreichern der Produktdaten ist ein unerwarteter kritischer Fehler aufgetreten." };

--- a/src/ai/flows/extract-bank-statement-data.ts
+++ b/src/ai/flows/extract-bank-statement-data.ts
@@ -51,7 +51,7 @@ const ExtractBankStatementDataOutputSchema = z.object({
 export type ExtractBankStatementDataOutput = z.infer<typeof ExtractBankStatementDataOutputSchema>;
 
 // Helper to parse German numbers from string if AI returns string amount
-function parseGermanNumberFromString(numStr: any): number | null {
+function parseGermanNumberFromString(numStr: unknown): number | null {
   if (typeof numStr === 'number') return numStr;
   if (typeof numStr !== 'string' || !numStr) return null;
   const cleanedStr = numStr.replace(/\./g, '').replace(/,/g, '.');
@@ -196,8 +196,8 @@ const extractBankStatementDataFlow = ai.defineFlow(
     try {
         const {output} = await prompt(input, {model: 'googleai/gemini-1.5-flash-latest'});
         return output || { transactions: [] };
-    } catch (e: any) {
-        if (e.message && (e.message.includes('503') || e.message.includes('overloaded'))) {
+    } catch (e: unknown) {
+        if (e instanceof Error && e.message && (e.message.includes('503') || e.message.includes('overloaded'))) {
             return { transactions: [], error: "The AI service is currently busy or unavailable. Please try again in a few moments." };
         }
         return { transactions: [], error: "An unexpected error occurred during bank statement extraction." };

--- a/src/ai/flows/extract-incoming-invoice-data.ts
+++ b/src/ai/flows/extract-incoming-invoice-data.ts
@@ -63,8 +63,8 @@ export type ExtractIncomingInvoiceDataOutput = {
 }
 
 // Helper function for product code normalization
-function normalizeProductCode(code: any): string {
-  let strCode = String(code || '').trim().replace(/\n/g, ' ');
+function normalizeProductCode(code: unknown): string {
+  let strCode = String(code ?? '').trim().replace(/\n/g, ' ');
   if (/^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)$/.test(strCode)) {
     const num = Number(strCode);
     if (!isNaN(num) && isFinite(num)) {
@@ -98,19 +98,19 @@ export async function extractIncomingInvoiceData(input: ExtractIncomingInvoiceDa
 
 
   const normalizedOutput: ExtractIncomingInvoiceDataOutput = {
-    rechnungsnummer: rawOutput.invoiceNumber,
-    datum: rawOutput.invoiceDate,
-    lieferdatum: rawOutput.dueDate, // using dueDate as lieferdatum
+    rechnungsnummer: rawOutput.invoiceNumber ?? undefined,
+    datum: rawOutput.invoiceDate ?? undefined,
+    lieferdatum: rawOutput.dueDate ?? undefined, // using dueDate as lieferdatum
     lieferantName: String(rawOutput.supplier || '').trim().replace(/\n/g, ' '),
     lieferantAdresse: "", // Not in new prompt
     kundenName: "", // Not in new prompt
     kundenAdresse: "", // Not in new prompt
     zahlungsziel: "", // Not in new prompt
     zahlungsart: "", // Not in new prompt
-    nettoBetrag: rawOutput.nettoBetrag,
-    mwstBetrag: rawOutput.mwstBetrag,
-    gesamtbetrag: rawOutput.bruttoBetrag,
-    waehrung: rawOutput.currency,
+    nettoBetrag: rawOutput.nettoBetrag ?? undefined,
+    mwstBetrag: rawOutput.mwstBetrag ?? undefined,
+    gesamtbetrag: rawOutput.bruttoBetrag ?? undefined,
+    waehrung: rawOutput.currency ?? undefined,
     steuersaetze: [], // Not in new prompt
     mwstSatz: mainVatRate,
     kundenNummer: "", // Not in new prompt
@@ -200,18 +200,18 @@ const extractIncomingInvoiceDataFlow = ai.defineFlow(
            };
         }
         return output;
-    } catch (e: any) {
+    } catch (e: unknown) {
         console.error("Critical error in extractIncomingInvoiceDataFlow:", e);
-        if (e.message && (e.message.includes('503') || e.message.includes('overloaded'))) {
-            return { 
+        if (e instanceof Error && e.message && (e.message.includes('503') || e.message.includes('overloaded'))) {
+            return {
                 supplier: null, invoiceNumber: null, invoiceDate: null, dueDate: null,
                 nettoBetrag: null, mwstBetrag: null, bruttoBetrag: null, currency: null,
                 items: [], error: "The AI service is currently busy or unavailable. Please try again in a few moments." };
         }
-        return { 
+        return {
             supplier: null, invoiceNumber: null, invoiceDate: null, dueDate: null,
             nettoBetrag: null, mwstBetrag: null, bruttoBetrag: null, currency: null,
-            items: [], error: `An unexpected error occurred during invoice extraction: ${e.message}` };
+            items: [], error: `An unexpected error occurred during invoice extraction: ${e instanceof Error ? e.message : String(e)}` };
     }
   }
 );

--- a/src/ai/flows/extract-invoice-data.ts
+++ b/src/ai/flows/extract-invoice-data.ts
@@ -39,8 +39,8 @@ export type ExtractInvoiceDataOutput = {
 
 
 // Helper function for product code normalization
-function normalizeProductCode(code: any): string {
-  let strCode = String(code || '').trim().replace(/\n/g, ' ');
+function normalizeProductCode(code: unknown): string {
+  let strCode = String(code ?? '').trim().replace(/\n/g, ' ');
   // Check if it's in scientific notation (e.g., "1.23e+5", "1.23E-5", "4.335747e+11")
   if (/^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)$/.test(strCode)) {
     const num = Number(strCode);
@@ -63,8 +63,8 @@ export async function extractInvoiceData(input: ExtractInvoiceDataInput): Promis
   const normalizedInvoiceDetails: AppLineItem[] = (rawOutput.invoiceDetails || []).map(item => ({
     productCode: normalizeProductCode(item.productCode),
     productName: String(item.productName || '').trim().replace(/\n/g, ' '),
-    quantity: item.quantity === undefined ? 0 : item.quantity, // Default to 0 if undefined
-    unitPrice: item.unitPrice === undefined ? 0.0 : item.unitPrice, // Default to 0.0 if undefined
+    quantity: item.quantity == null ? 0 : item.quantity,
+    unitPrice: item.unitPrice == null ? 0.0 : item.unitPrice,
   }));
   
   return { invoiceDetails: normalizedInvoiceDetails };
@@ -98,8 +98,8 @@ const extractInvoiceDataFlow = ai.defineFlow(
     try {
         const {output} = await prompt(input, {model: 'googleai/gemini-1.5-flash-latest'});
         return output || { invoiceDetails: [] };
-    } catch (e: any) {
-        if (e.message && (e.message.includes('503') || e.message.includes('overloaded'))) {
+    } catch (e: unknown) {
+        if (e instanceof Error && e.message && (e.message.includes('503') || e.message.includes('overloaded'))) {
             return { invoiceDetails: [], error: "The AI service is currently busy or unavailable. Please try again in a few moments." };
         }
         return { invoiceDetails: [], error: "An unexpected error occurred during invoice data extraction." };

--- a/src/ai/flows/normalize-and-deduplicate-data.ts
+++ b/src/ai/flows/normalize-and-deduplicate-data.ts
@@ -19,8 +19,8 @@ const NormalizeAndDeduplicateOutputSchema = z.array(ProcessedLineItemSchema);
 export type NormalizeAndDeduplicateOutput = z.infer<typeof NormalizeAndDeduplicateOutputSchema>;
 
 // Helper function for product code normalization (can be shared or defined locally)
-function normalizeProductCode(code: any): string {
-  let strCode = String(code || '').trim().replace(/\n/g, ' ');
+function normalizeProductCode(code: unknown): string {
+  let strCode = String(code ?? '').trim().replace(/\n/g, ' ');
   // Check if it's in scientific notation (e.g., "1.23e+5", "1.23E-5", "4.335747e+11")
   if (/^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)$/.test(strCode)) {
     const num = Number(strCode);

--- a/src/ai/flows/suggest-pdf-filename.ts
+++ b/src/ai/flows/suggest-pdf-filename.ts
@@ -111,8 +111,8 @@ const suggestPdfFilenameFlow = ai.defineFlow(
     try {
       const { output } = await prompt(input, {model: 'googleai/gemini-1.5-flash-latest'});
       return output || { suggestedFilename: `Processed_${input.originalFilename}` };
-    } catch (e: any) {
-        if (e.message && (e.message.includes('503') || e.message.includes('overloaded'))) {
+    } catch (e: unknown) {
+        if (e instanceof Error && e.message && (e.message.includes('503') || e.message.includes('overloaded'))) {
             return { suggestedFilename: `Error_${input.originalFilename}`, error: "The AI service is currently busy or unavailable. Please try again in a few moments." };
         }
         return { suggestedFilename: `Error_${input.originalFilename}`, error: "An unexpected error occurred while suggesting a filename." };

--- a/src/app/api/erpnext/export-invoice/route.ts
+++ b/src/app/api/erpnext/export-invoice/route.ts
@@ -90,11 +90,15 @@ export async function POST(request: Request) {
 
         successCount++;
 
-      } catch (e: any) {
+      } catch (e: unknown) {
         errorCount++;
-        const errorMessage = e.message || "Unknown error during individual invoice export";
+        const errorMessage = e instanceof Error ? e.message : "Unknown error during individual invoice export";
         errors.push({ invoiceNumber: invoice.rechnungsnummer || invoice.pdfFileName, error: errorMessage });
-        console.error(`[ExportERP API] Failed to export invoice ${invoice.rechnungsnummer} to ERPNext:`, errorMessage, e.stack);
+        console.error(
+          `[ExportERP API] Failed to export invoice ${invoice.rechnungsnummer} to ERPNext:`,
+          errorMessage,
+          e instanceof Error ? e.stack : e
+        );
       }
     }
 
@@ -112,8 +116,15 @@ export async function POST(request: Request) {
     console.log(`[ExportERP API] ${successCount} invoice(s) successfully SIMULATED for ERPNext.`);
     return NextResponse.json({ message: `${successCount} invoice(s) successfully submitted to ERPNext (SIMULATED).` });
 
-  } catch (error: any) {
-    console.error('[ExportERP API] Critical Error in /api/erpnext/export-invoice:', error.message, error.stack);
-    return NextResponse.json({ error: error.message || 'An unexpected critical error occurred on the server.' }, { status: 500 });
+  } catch (error: unknown) {
+    console.error(
+      '[ExportERP API] Critical Error in /api/erpnext/export-invoice:',
+      error instanceof Error ? error.message : error,
+      error instanceof Error ? error.stack : undefined
+    );
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'An unexpected critical error occurred on the server.' },
+      { status: 500 }
+    );
   }
 }

--- a/src/components/bank-matcher/BankMatcherPageContent.tsx
+++ b/src/components/bank-matcher/BankMatcherPageContent.tsx
@@ -50,7 +50,7 @@ const sortOptions: { key: BankMatcherSortKey; label: string }[] = [
   { key: 'transaction.description', label: 'Tx Description' },
 ];
 
-function compareValues(valA: any, valB: any, order: SortOrder): number {
+function compareValues(valA: unknown, valB: unknown, order: SortOrder): number {
   const aIsNil = valA === null || valA === undefined || valA === '';
   const bIsNil = valB === null || valB === undefined || valB === '';
 

--- a/src/components/bank-statement-extractor/BankStatementDataTable.tsx
+++ b/src/components/bank-statement-extractor/BankStatementDataTable.tsx
@@ -38,8 +38,6 @@ export function BankStatementDataTable({ transactions }: BankStatementDataTableP
         comparison = valA - valB;
       } else if (typeof valA === 'string' && typeof valB === 'string') {
         comparison = valA.localeCompare(valB);
-      } else if (valA instanceof Date && valB instanceof Date) {
-        comparison = valA.getTime() - valB.getTime();
       }
 
       return sortOrder === 'asc' ? comparison : -comparison;

--- a/src/components/product-catalog/ProductCatalogActionButtons.tsx
+++ b/src/components/product-catalog/ProductCatalogActionButtons.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { productsToCSV, productsToJSON, downloadFile } from '@/lib/export-product-data';
-import type { EnrichedProduct } from '@/ai/flows/enrich-product-data';
+import type { EnrichedProduct } from '@/ai/schemas/product-catalog-schema';
 import { FileJson, FileSpreadsheet } from 'lucide-react';
 
 interface ProductCatalogActionButtonsProps {

--- a/src/lib/bank-matcher/bankStatementParser.ts
+++ b/src/lib/bank-matcher/bankStatementParser.ts
@@ -58,25 +58,27 @@ export async function parseBankStatementCSV(file: File): Promise<BankTransaction
           // Potentially reject only on critical errors or provide partial data
         }
         
-        const transactions: BankTransaction[] = results.data.map((row, index) => {
-          const date = parseDate(row['Datum'] || row['Date']);
-          const amount = parseGermanNumber(row['Betrag'] || row['Amount']);
-          const description = row['Buchungstext'] || row['Description'] || row['Verwendungszweck'] || '';
-          
-          if (!date || amount === null) {
-            console.warn(`Skipping row ${index + 2} due to missing/invalid date or amount:`, row);
-            return null; 
-          }
+        const transactions = results.data
+          .map((row, index): BankTransaction | null => {
+            const date = parseDate(row['Datum'] || row['Date']);
+            const amount = parseGermanNumber(row['Betrag'] || row['Amount']);
+            const description = row['Buchungstext'] || row['Description'] || row['Verwendungszweck'] || '';
 
-          return {
-            id: uuidv4(), // Generate a unique ID
-            date: date,
-            description: description,
-            amount: amount,
-            currency: row['Währung'] || row['Currency'] || 'EUR',
-            recipientOrPayer: row['Empfänger/Zahlungspflichtiger'] || row['Auftraggeber/Empfänger'] || row['Name'] || '',
-          };
-        }).filter((t): t is BankTransaction => t !== null); // Filter out nulls
+            if (!date || amount === null) {
+              console.warn(`Skipping row ${index + 2} due to missing/invalid date or amount:`, row);
+              return null;
+            }
+
+            return {
+              id: uuidv4(), // Generate a unique ID
+              date: date,
+              description: description,
+              amount: amount,
+              currency: row['Währung'] || row['Currency'] || 'EUR',
+              recipientOrPayer: row['Empfänger/Zahlungspflichtiger'] || row['Auftraggeber/Empfänger'] || row['Name'] || '',
+            };
+          })
+          .filter((t): t is BankTransaction => t !== null); // Filter out nulls
 
         resolve(transactions);
       },

--- a/src/lib/bank-matcher/exportMatchedTransactions.ts
+++ b/src/lib/bank-matcher/exportMatchedTransactions.ts
@@ -60,7 +60,7 @@ function getDetailedRowData(match: MatchedTransaction): (string | number | undef
     matchedInvoice?.mwstSatz,
     matchedInvoice?.kundenNummer,
     matchedInvoice?.bestellNummer,
-    matchedInvoice?.isPaidByAI,
+    matchedInvoice?.isPaidByAI ? 1 : 0,
     matchedInvoice?.istBezahlt,
     matchedInvoice?.kontenrahmen,
     matchedInvoice?.billDate,


### PR DESCRIPTION
## Summary
- replace remaining `any` usages with `unknown` or explicit interfaces across API routes, AI flows, and components
- tighten CSV and error-handling logic with concrete typing and safer runtime checks

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689b59dbdfd483238398f88f067aef74