### PR TITLE
feat(erpnext): add mappers for invoices, items, bank and stock

### DIFF
--- a/src/lib/erpnext/mappers/bank.ts
+++ b/src/lib/erpnext/mappers/bank.ts
@@ -1,0 +1,63 @@
+import type { BankTransaction as InternalBankTransaction } from '@/lib/bank-matcher/types';
+import type { BankTransaction } from '../types';
+
+interface MapperOptions {
+  dryRun?: boolean;
+  endpoint?: string;
+  headers?: Record<string, string>;
+}
+
+function escapeCSVField(field: string | number | undefined | null): string {
+  if (field === undefined || field === null) return '';
+  const stringField = String(field);
+  if (stringField.includes('"') || stringField.includes(',') || stringField.includes('\n') || stringField.includes('\r')) {
+    return `"${stringField.replace(/"/g, '""')}"`;
+  }
+  return stringField;
+}
+
+export async function mapBankTransaction(
+  tx: InternalBankTransaction,
+  options: MapperOptions = {}
+): Promise<{ payload: BankTransaction; csv: string; response?: unknown }> {
+  const payload: BankTransaction = {
+    doctype: 'Bank Transaction',
+    date: tx.date,
+    account: tx.recipientOrPayer || '',
+    description: tx.description,
+    deposit: tx.amount > 0 ? tx.amount : undefined,
+    withdrawal: tx.amount < 0 ? Math.abs(tx.amount) : undefined,
+    reference_number: tx.id,
+    party: tx.recipientOrPayer,
+  };
+
+  const csv = [
+    tx.date,
+    tx.amount > 0 ? tx.amount : '',
+    tx.amount < 0 ? Math.abs(tx.amount) : '',
+    tx.description,
+    tx.id,
+    tx.recipientOrPayer,
+    tx.currency || 'EUR',
+  ].map(escapeCSVField).join(',');
+
+  if (!options.dryRun && options.endpoint) {
+    const response = await fetch(options.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(options.headers || {}),
+      },
+      body: JSON.stringify(payload),
+    });
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      data = await response.text();
+    }
+    return { payload, csv, response: data };
+  }
+
+  return { payload, csv };
+}

--- a/src/lib/erpnext/mappers/invoice.ts
+++ b/src/lib/erpnext/mappers/invoice.ts
@@ -1,0 +1,92 @@
+import type { ERPIncomingInvoiceItem } from '@/types/incoming-invoice';
+import type { PurchaseInvoice } from '../types';
+
+interface MapperOptions {
+  /** When true, no network calls are made. */
+  dryRun?: boolean;
+  /** Optional endpoint to post the payload to ERPNext. */
+  endpoint?: string;
+  /** Extra headers for the request such as authentication. */
+  headers?: Record<string, string>;
+}
+
+function escapeCSVField(field: string | number | undefined | null): string {
+  if (field === undefined || field === null) return '';
+  const stringField = String(field);
+  if (stringField.includes('"') || stringField.includes(',') || stringField.includes('\n') || stringField.includes('\r')) {
+    return `"${stringField.replace(/"/g, '""')}"`;
+  }
+  return stringField;
+}
+
+/**
+ * Map an internal invoice representation to an ERPNext Purchase Invoice payload
+ * and CSV row(s). If `options.dryRun` is false and `options.endpoint` is
+ * provided, the payload is POSTed to the given endpoint.
+ */
+export async function mapPurchaseInvoice(
+  invoice: ERPIncomingInvoiceItem,
+  options: MapperOptions = {}
+): Promise<{ payload: PurchaseInvoice; csv: string; response?: unknown }> {
+  const payload: PurchaseInvoice = {
+    doctype: 'Purchase Invoice',
+    supplier: invoice.lieferantName || '',
+    bill_no: invoice.rechnungsnummer,
+    posting_date: invoice.datum || new Date().toISOString().slice(0, 10),
+    due_date: invoice.dueDate,
+    currency: invoice.wahrung || 'EUR',
+    grand_total: invoice.gesamtbetrag,
+    is_paid: invoice.istBezahlt,
+    set_posting_time: 1,
+    items: (invoice.rechnungspositionen || []).map(item => ({
+      item_code: item.productCode,
+      item_name: item.productName,
+      description: item.productName,
+      qty: item.quantity,
+      rate: item.unitPrice,
+    })),
+  };
+
+  const invoiceData = [
+    invoice.lieferantName,
+    invoice.rechnungsnummer,
+    invoice.datum,
+    invoice.gesamtbetrag,
+  ].map(escapeCSVField);
+
+  const csvRows: string[] = [];
+  if (invoice.rechnungspositionen && invoice.rechnungspositionen.length > 0) {
+    invoice.rechnungspositionen.forEach(item => {
+      const row = [
+        ...invoiceData,
+        escapeCSVField(item.productCode),
+        escapeCSVField(item.productName),
+        item.quantity.toString(),
+        item.unitPrice.toString(),
+      ];
+      csvRows.push(row.join(','));
+    });
+  } else {
+    csvRows.push(invoiceData.join(','));
+  }
+
+  if (!options.dryRun && options.endpoint) {
+    const response = await fetch(options.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(options.headers || {}),
+      },
+      body: JSON.stringify(payload),
+    });
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      data = await response.text();
+    }
+    return { payload, csv: csvRows.join('\n'), response: data };
+  }
+
+  return { payload, csv: csvRows.join('\n') };
+}

--- a/src/lib/erpnext/mappers/item.ts
+++ b/src/lib/erpnext/mappers/item.ts
@@ -1,0 +1,68 @@
+import type { ItemPayload } from '../types';
+
+export interface InternalItem {
+  code: string;
+  name: string;
+  description?: string;
+  group: string;
+  uom: string;
+  isStockItem?: boolean;
+}
+
+interface MapperOptions {
+  dryRun?: boolean;
+  endpoint?: string;
+  headers?: Record<string, string>;
+}
+
+function escapeCSVField(field: string | number | undefined | null): string {
+  if (field === undefined || field === null) return '';
+  const stringField = String(field);
+  if (stringField.includes('"') || stringField.includes(',') || stringField.includes('\n') || stringField.includes('\r')) {
+    return `"${stringField.replace(/"/g, '""')}"`;
+  }
+  return stringField;
+}
+
+export async function mapItem(
+  item: InternalItem,
+  options: MapperOptions = {}
+): Promise<{ payload: ItemPayload; csv: string; response?: unknown }> {
+  const payload: ItemPayload = {
+    doctype: 'Item',
+    item_code: item.code,
+    item_name: item.name,
+    description: item.description,
+    item_group: item.group,
+    stock_uom: item.uom,
+    is_stock_item: item.isStockItem,
+  };
+
+  const csv = [
+    item.code,
+    item.name,
+    item.group,
+    item.uom,
+    item.isStockItem ? 1 : 0,
+  ].map(escapeCSVField).join(',');
+
+  if (!options.dryRun && options.endpoint) {
+    const response = await fetch(options.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(options.headers || {}),
+      },
+      body: JSON.stringify(payload),
+    });
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      data = await response.text();
+    }
+    return { payload, csv, response: data };
+  }
+
+  return { payload, csv };
+}

--- a/src/lib/erpnext/mappers/stock.ts
+++ b/src/lib/erpnext/mappers/stock.ts
@@ -1,0 +1,139 @@
+import type { StockEntry, StockReconciliation } from '../types';
+
+export interface InternalStockReconciliation {
+  postingDate: string;
+  company?: string;
+  purpose?: string;
+  items: {
+    itemCode: string;
+    warehouse: string;
+    qty: number;
+    valuationRate?: number;
+  }[];
+}
+
+export interface InternalStockEntry {
+  postingDate: string;
+  purpose: string;
+  company?: string;
+  items: {
+    itemCode: string;
+    sWarehouse?: string;
+    tWarehouse?: string;
+    qty: number;
+    basicRate?: number;
+  }[];
+}
+
+interface MapperOptions {
+  dryRun?: boolean;
+  endpoint?: string;
+  headers?: Record<string, string>;
+}
+
+function escapeCSVField(field: string | number | undefined | null): string {
+  if (field === undefined || field === null) return '';
+  const stringField = String(field);
+  if (stringField.includes('"') || stringField.includes(',') || stringField.includes('\n') || stringField.includes('\r')) {
+    return `"${stringField.replace(/"/g, '""')}"`;
+  }
+  return stringField;
+}
+
+export async function mapStockReconciliation(
+  stock: InternalStockReconciliation,
+  options: MapperOptions = {}
+): Promise<{ payload: StockReconciliation; csv: string; response?: unknown }> {
+  const payload: StockReconciliation = {
+    doctype: 'Stock Reconciliation',
+    posting_date: stock.postingDate,
+    company: stock.company,
+    purpose: stock.purpose,
+    items: stock.items.map(it => ({
+      item_code: it.itemCode,
+      warehouse: it.warehouse,
+      qty: it.qty,
+      valuation_rate: it.valuationRate,
+    })),
+  };
+
+  const csvRows = stock.items.map(it => [
+    stock.postingDate,
+    stock.company,
+    stock.purpose,
+    it.itemCode,
+    it.warehouse,
+    it.qty,
+    it.valuationRate ?? '',
+  ].map(escapeCSVField).join(','));
+
+  if (!options.dryRun && options.endpoint) {
+    const response = await fetch(options.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(options.headers || {}),
+      },
+      body: JSON.stringify(payload),
+    });
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      data = await response.text();
+    }
+    return { payload, csv: csvRows.join('\n'), response: data };
+  }
+
+  return { payload, csv: csvRows.join('\n') };
+}
+
+export async function mapStockEntry(
+  entry: InternalStockEntry,
+  options: MapperOptions = {}
+): Promise<{ payload: StockEntry; csv: string; response?: unknown }> {
+  const payload: StockEntry = {
+    doctype: 'Stock Entry',
+    posting_date: entry.postingDate,
+    purpose: entry.purpose,
+    company: entry.company,
+    items: entry.items.map(it => ({
+      item_code: it.itemCode,
+      s_warehouse: it.sWarehouse,
+      t_warehouse: it.tWarehouse,
+      qty: it.qty,
+      basic_rate: it.basicRate,
+    })),
+  };
+
+  const csvRows = entry.items.map(it => [
+    entry.postingDate,
+    entry.purpose,
+    entry.company,
+    it.itemCode,
+    it.sWarehouse || '',
+    it.tWarehouse || '',
+    it.qty,
+    it.basicRate ?? '',
+  ].map(escapeCSVField).join(','));
+
+  if (!options.dryRun && options.endpoint) {
+    const response = await fetch(options.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(options.headers || {}),
+      },
+      body: JSON.stringify(payload),
+    });
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      data = await response.text();
+    }
+    return { payload, csv: csvRows.join('\n'), response: data };
+  }
+
+  return { payload, csv: csvRows.join('\n') };
+}


### PR DESCRIPTION
## Summary
- add mapper for Purchase Invoice converting internal invoices into ERPNext payloads and CSV rows
- support Item master mapping with dry-run option
- provide bank transaction mapper and stock movement mappers (reconciliation & entry)

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: requires interactive configuration)
- `npm run typecheck` (fails: existing type errors)


------
https://chatgpt.com/codex/tasks/task_e_68ae18405e60832383bda8f51f6207fd