### PR TITLE
feat: add ERPNext idempotency and dedupe services

### DIFF
--- a/src/lib/erpnext/idempotency.ts
+++ b/src/lib/erpnext/idempotency.ts
@@ -1,0 +1,63 @@
+import type {
+  PurchaseInvoice,
+  ItemPayload,
+  BankTransaction,
+  StockReconciliation,
+  StockEntry,
+} from './types';
+
+function normalise(part: unknown): string {
+  if (typeof part === 'number') {
+    return part.toFixed(2);
+  }
+  return String(part ?? '').trim().toLowerCase();
+}
+
+export function buildKey(parts: unknown[]): string {
+  return parts.map(normalise).join('|');
+}
+
+export function purchaseInvoiceKey(
+  invoice: Pick<PurchaseInvoice, 'supplier' | 'bill_no' | 'posting_date' | 'grand_total'>,
+): string {
+  return buildKey([
+    invoice.supplier,
+    invoice.bill_no,
+    invoice.posting_date,
+    invoice.grand_total,
+  ]);
+}
+
+export function itemKey(item: Pick<ItemPayload, 'item_code'>): string {
+  return buildKey([item.item_code]);
+}
+
+export function bankTransactionKey(
+  tx: Pick<BankTransaction, 'date' | 'deposit' | 'withdrawal' | 'reference_number'>,
+): string {
+  const amount = tx.deposit ?? (tx.withdrawal ? -tx.withdrawal : 0);
+  return buildKey([tx.date, amount, tx.reference_number]);
+}
+
+export function stockReconciliationKey(
+  doc: Pick<StockReconciliation, 'posting_date' | 'items'>,
+): string {
+  const items = [...doc.items]
+    .map(it => buildKey([it.item_code, it.warehouse, it.qty]))
+    .sort()
+    .join(';');
+  return buildKey([doc.posting_date, items]);
+}
+
+export function stockEntryKey(
+  doc: Pick<StockEntry, 'posting_date' | 'purpose' | 'items'>,
+): string {
+  const items = [...doc.items]
+    .map(it => buildKey([it.item_code, it.s_warehouse, it.t_warehouse, it.qty]))
+    .sort()
+    .join(';');
+  return buildKey([doc.posting_date, doc.purpose, items]);
+}
+
+export type IdempotencyKeyBuilder<T> = (doc: T) => string;
+

--- a/src/lib/erpnext/mappers/bank.ts
+++ b/src/lib/erpnext/mappers/bank.ts
@@ -1,5 +1,6 @@
 import type { BankTransaction as InternalBankTransaction } from '@/lib/bank-matcher/types';
 import type { BankTransaction } from '../types';
+import { findExistingBankTransaction } from '../services/dedupe';
 
 interface MapperOptions {
   dryRun?: boolean;
@@ -42,6 +43,14 @@ export async function mapBankTransaction(
   ].map(escapeCSVField).join(',');
 
   if (!options.dryRun && options.endpoint) {
+    const existing = await findExistingBankTransaction(payload, {
+      endpoint: options.endpoint,
+      headers: options.headers,
+    });
+    if (existing) {
+      return { payload, csv, response: { duplicate: true, existing } };
+    }
+
     const response = await fetch(options.endpoint, {
       method: 'POST',
       headers: {

--- a/src/lib/erpnext/mappers/invoice.ts
+++ b/src/lib/erpnext/mappers/invoice.ts
@@ -1,5 +1,6 @@
 import type { ERPIncomingInvoiceItem } from '@/types/incoming-invoice';
 import type { PurchaseInvoice } from '../types';
+import { findExistingPurchaseInvoice } from '../services/dedupe';
 
 interface MapperOptions {
   /** When true, no network calls are made. */
@@ -71,6 +72,18 @@ export async function mapPurchaseInvoice(
   }
 
   if (!options.dryRun && options.endpoint) {
+    const existing = await findExistingPurchaseInvoice(payload, {
+      endpoint: options.endpoint,
+      headers: options.headers,
+    });
+    if (existing) {
+      return {
+        payload,
+        csv: csvRows.join('\n'),
+        response: { duplicate: true, existing },
+      };
+    }
+
     const response = await fetch(options.endpoint, {
       method: 'POST',
       headers: {

--- a/src/lib/erpnext/mappers/item.ts
+++ b/src/lib/erpnext/mappers/item.ts
@@ -1,4 +1,5 @@
 import type { ItemPayload } from '../types';
+import { findExistingItem } from '../services/dedupe';
 
 export interface InternalItem {
   code: string;
@@ -47,6 +48,14 @@ export async function mapItem(
   ].map(escapeCSVField).join(',');
 
   if (!options.dryRun && options.endpoint) {
+    const existing = await findExistingItem(payload, {
+      endpoint: options.endpoint,
+      headers: options.headers,
+    });
+    if (existing) {
+      return { payload, csv, response: { duplicate: true, existing } };
+    }
+
     const response = await fetch(options.endpoint, {
       method: 'POST',
       headers: {

--- a/src/lib/erpnext/mappers/stock.ts
+++ b/src/lib/erpnext/mappers/stock.ts
@@ -1,4 +1,5 @@
 import type { StockEntry, StockReconciliation } from '../types';
+import { isDuplicateStockEntry, isDuplicateStockReconciliation } from '../services/dedupe';
 
 export interface InternalStockReconciliation {
   postingDate: string;
@@ -68,6 +69,14 @@ export async function mapStockReconciliation(
   ].map(escapeCSVField).join(','));
 
   if (!options.dryRun && options.endpoint) {
+    if (isDuplicateStockReconciliation(payload)) {
+      return {
+        payload,
+        csv: csvRows.join('\n'),
+        response: { duplicate: true },
+      };
+    }
+
     const response = await fetch(options.endpoint, {
       method: 'POST',
       headers: {
@@ -118,6 +127,14 @@ export async function mapStockEntry(
   ].map(escapeCSVField).join(','));
 
   if (!options.dryRun && options.endpoint) {
+    if (isDuplicateStockEntry(payload)) {
+      return {
+        payload,
+        csv: csvRows.join('\n'),
+        response: { duplicate: true },
+      };
+    }
+
     const response = await fetch(options.endpoint, {
       method: 'POST',
       headers: {

--- a/src/lib/erpnext/services/dedupe.ts
+++ b/src/lib/erpnext/services/dedupe.ts
@@ -1,0 +1,131 @@
+import type {
+  PurchaseInvoice,
+  ItemPayload,
+  BankTransaction,
+  StockReconciliation,
+  StockEntry,
+} from '../types';
+import {
+  purchaseInvoiceKey,
+  itemKey,
+  bankTransactionKey,
+  stockReconciliationKey,
+  stockEntryKey,
+} from '../idempotency';
+
+type Options = {
+  endpoint: string;
+  headers?: Record<string, string>;
+};
+
+const localCache = new Map<string, Set<string>>();
+
+function markLocal(doctype: string, key: string): boolean {
+  let set = localCache.get(doctype);
+  if (!set) {
+    set = new Set();
+    localCache.set(doctype, set);
+  }
+  if (set.has(key)) return true;
+  set.add(key);
+  return false;
+}
+
+async function queryERPNext(
+  endpoint: string,
+  filters: unknown[],
+  fields: string[],
+  headers?: Record<string, string>,
+): Promise<any[]> {
+  const url = new URL(endpoint);
+  url.searchParams.set('filters', JSON.stringify(filters));
+  url.searchParams.set('fields', JSON.stringify(fields));
+  url.searchParams.set('limit', '20');
+  const res = await fetch(url.toString(), { headers });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return Array.isArray(data.data) ? data.data : [];
+}
+
+export async function findExistingPurchaseInvoice(
+  invoice: PurchaseInvoice,
+  options: Options,
+): Promise<any | undefined> {
+  const key = purchaseInvoiceKey(invoice);
+  if (markLocal('Purchase Invoice', key)) {
+    return { localDuplicate: true };
+  }
+
+  const filters = [
+    ['Purchase Invoice', 'supplier', '=', invoice.supplier],
+    ['Purchase Invoice', 'bill_no', '=', invoice.bill_no],
+  ];
+  const rows = await queryERPNext(
+    options.endpoint,
+    filters,
+    ['name', 'supplier', 'bill_no', 'posting_date', 'grand_total'],
+    options.headers,
+  );
+  return rows.find(r =>
+    purchaseInvoiceKey({
+      supplier: r.supplier,
+      bill_no: r.bill_no,
+      posting_date: r.posting_date,
+      grand_total: Number(r.grand_total),
+    }) === key,
+  );
+}
+
+export async function findExistingItem(
+  item: ItemPayload,
+  options: Options,
+): Promise<any | undefined> {
+  const key = itemKey(item);
+  if (markLocal('Item', key)) {
+    return { localDuplicate: true };
+  }
+
+  const filters = [['Item', 'item_code', '=', item.item_code]];
+  const rows = await queryERPNext(options.endpoint, filters, ['name', 'item_code'], options.headers);
+  return rows.find(r => itemKey({ item_code: r.item_code }) === key);
+}
+
+export async function findExistingBankTransaction(
+  tx: BankTransaction,
+  options: Options,
+): Promise<any | undefined> {
+  const key = bankTransactionKey(tx);
+  if (markLocal('Bank Transaction', key)) {
+    return { localDuplicate: true };
+  }
+
+  const filters = [
+    ['Bank Transaction', 'date', '=', tx.date],
+    ['Bank Transaction', 'reference_number', '=', tx.reference_number],
+  ];
+  const rows = await queryERPNext(
+    options.endpoint,
+    filters,
+    ['name', 'date', 'deposit', 'withdrawal', 'reference_number'],
+    options.headers,
+  );
+  return rows.find(r =>
+    bankTransactionKey({
+      date: r.date,
+      deposit: Number(r.deposit),
+      withdrawal: Number(r.withdrawal),
+      reference_number: r.reference_number,
+    }) === key,
+  );
+}
+
+export function isDuplicateStockReconciliation(doc: StockReconciliation): boolean {
+  const key = stockReconciliationKey(doc);
+  return markLocal('Stock Reconciliation', key);
+}
+
+export function isDuplicateStockEntry(doc: StockEntry): boolean {
+  const key = stockEntryKey(doc);
+  return markLocal('Stock Entry', key);
+}
+


### PR DESCRIPTION
## Summary
- add deterministic idempotency key builders for ERPNext documents
- add tolerant dedupe utilities to check ERPNext for existing docs
- use dedupe before creating Purchase Invoice, Item, Bank Transaction, and stock docs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find module 'react'...)*

------
https://chatgpt.com/codex/tasks/task_e_68ae200f48588323ae11d6e4400e85ee