### PR TITLE
feat: add SKU resolver service

### DIFF
--- a/src/lib/erpnext/mappers/invoice.ts
+++ b/src/lib/erpnext/mappers/invoice.ts
@@ -1,6 +1,7 @@
 import type { ERPIncomingInvoiceItem } from '@/types/incoming-invoice';
 import type { PurchaseInvoice } from '../types';
 import { findExistingPurchaseInvoice } from '../services/dedupe';
+import { resolveOrCreateItem } from '../services/sku-resolver';
 
 interface MapperOptions {
   /** When true, no network calls are made. */
@@ -29,6 +30,16 @@ export async function mapPurchaseInvoice(
   invoice: ERPIncomingInvoiceItem,
   options: MapperOptions = {}
 ): Promise<{ payload: PurchaseInvoice; csv: string; response?: unknown }> {
+  const resolvedItems = await Promise.all(
+    (invoice.rechnungspositionen || []).map(async item => ({
+      ...item,
+      itemCode: await resolveOrCreateItem({
+        supplierCode: item.productCode,
+        name: item.productName,
+      }),
+    })),
+  );
+
   const payload: PurchaseInvoice = {
     doctype: 'Purchase Invoice',
     supplier: invoice.lieferantName || '',
@@ -39,8 +50,8 @@ export async function mapPurchaseInvoice(
     grand_total: invoice.gesamtbetrag,
     is_paid: invoice.istBezahlt,
     set_posting_time: 1,
-    items: (invoice.rechnungspositionen || []).map(item => ({
-      item_code: item.productCode,
+    items: resolvedItems.map(item => ({
+      item_code: item.itemCode,
       item_name: item.productName,
       description: item.productName,
       qty: item.quantity,
@@ -56,11 +67,11 @@ export async function mapPurchaseInvoice(
   ].map(escapeCSVField);
 
   const csvRows: string[] = [];
-  if (invoice.rechnungspositionen && invoice.rechnungspositionen.length > 0) {
-    invoice.rechnungspositionen.forEach(item => {
+  if (resolvedItems.length > 0) {
+    resolvedItems.forEach(item => {
       const row = [
         ...invoiceData,
-        escapeCSVField(item.productCode),
+        escapeCSVField(item.itemCode),
         escapeCSVField(item.productName),
         item.quantity.toString(),
         item.unitPrice.toString(),

--- a/src/lib/erpnext/mappers/stock.ts
+++ b/src/lib/erpnext/mappers/stock.ts
@@ -1,5 +1,6 @@
 import type { StockEntry, StockReconciliation } from '../types';
 import { isDuplicateStockEntry, isDuplicateStockReconciliation } from '../services/dedupe';
+import { resolveOrCreateItem } from '../services/sku-resolver';
 
 export interface InternalStockReconciliation {
   postingDate: string;
@@ -41,32 +42,42 @@ function escapeCSVField(field: string | number | undefined | null): string {
   return stringField;
 }
 
-export async function mapStockReconciliation(
-  stock: InternalStockReconciliation,
-  options: MapperOptions = {}
-): Promise<{ payload: StockReconciliation; csv: string; response?: unknown }> {
-  const payload: StockReconciliation = {
-    doctype: 'Stock Reconciliation',
-    posting_date: stock.postingDate,
-    company: stock.company,
-    purpose: stock.purpose,
-    items: stock.items.map(it => ({
-      item_code: it.itemCode,
-      warehouse: it.warehouse,
-      qty: it.qty,
-      valuation_rate: it.valuationRate,
-    })),
-  };
+  export async function mapStockReconciliation(
+    stock: InternalStockReconciliation,
+    options: MapperOptions = {}
+  ): Promise<{ payload: StockReconciliation; csv: string; response?: unknown }> {
+    const resolvedItems = await Promise.all(
+      stock.items.map(async it => ({
+        ...it,
+        itemCode: await resolveOrCreateItem({
+          supplierCode: it.itemCode,
+          name: it.itemCode,
+        }),
+      }))
+    );
 
-  const csvRows = stock.items.map(it => [
-    stock.postingDate,
-    stock.company,
-    stock.purpose,
-    it.itemCode,
-    it.warehouse,
-    it.qty,
-    it.valuationRate ?? '',
-  ].map(escapeCSVField).join(','));
+    const payload: StockReconciliation = {
+      doctype: 'Stock Reconciliation',
+      posting_date: stock.postingDate,
+      company: stock.company,
+      purpose: stock.purpose,
+      items: resolvedItems.map(it => ({
+        item_code: it.itemCode,
+        warehouse: it.warehouse,
+        qty: it.qty,
+        valuation_rate: it.valuationRate,
+      })),
+    };
+
+    const csvRows = resolvedItems.map(it => [
+      stock.postingDate,
+      stock.company,
+      stock.purpose,
+      it.itemCode,
+      it.warehouse,
+      it.qty,
+      it.valuationRate ?? '',
+    ].map(escapeCSVField).join(','));
 
   if (!options.dryRun && options.endpoint) {
     if (isDuplicateStockReconciliation(payload)) {
@@ -101,12 +112,22 @@ export async function mapStockEntry(
   entry: InternalStockEntry,
   options: MapperOptions = {}
 ): Promise<{ payload: StockEntry; csv: string; response?: unknown }> {
+  const resolvedItems = await Promise.all(
+    entry.items.map(async it => ({
+      ...it,
+      itemCode: await resolveOrCreateItem({
+        supplierCode: it.itemCode,
+        name: it.itemCode,
+      }),
+    })),
+  );
+
   const payload: StockEntry = {
     doctype: 'Stock Entry',
     posting_date: entry.postingDate,
     purpose: entry.purpose,
     company: entry.company,
-    items: entry.items.map(it => ({
+    items: resolvedItems.map(it => ({
       item_code: it.itemCode,
       s_warehouse: it.sWarehouse,
       t_warehouse: it.tWarehouse,
@@ -115,7 +136,7 @@ export async function mapStockEntry(
     })),
   };
 
-  const csvRows = entry.items.map(it => [
+  const csvRows = resolvedItems.map(it => [
     entry.postingDate,
     entry.purpose,
     entry.company,

--- a/src/lib/erpnext/services/sku-resolver.ts
+++ b/src/lib/erpnext/services/sku-resolver.ts
@@ -1,0 +1,150 @@
+import crypto from 'crypto';
+
+interface ResolverInput {
+  supplierCode?: string;
+  name: string;
+  brand?: string;
+}
+
+interface CatalogEntry {
+  itemCode: string;
+  supplierCodes: string[];
+  name: string;
+  brand?: string;
+  provisional?: boolean;
+  disabled?: boolean;
+}
+
+const STORAGE_KEY = 'erpnextCatalogMap';
+
+function normalise(str: string): string {
+  return str.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function similarity(a: string, b: string): number {
+  const al = a.length;
+  const bl = b.length;
+  const dp = Array.from({ length: al + 1 }, () => new Array(bl + 1).fill(0));
+  for (let i = 0; i <= al; i++) dp[i][0] = i;
+  for (let j = 0; j <= bl; j++) dp[0][j] = j;
+  for (let i = 1; i <= al; i++) {
+    for (let j = 1; j <= bl; j++) {
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+      );
+    }
+  }
+  const distance = dp[al][bl];
+  return 1 - distance / Math.max(al, bl, 1);
+}
+
+class CatalogMap {
+  private entries: CatalogEntry[] = [];
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        try {
+          this.entries = JSON.parse(raw);
+        } catch {
+          this.entries = [];
+        }
+      }
+    }
+  }
+
+  private persist(): void {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(this.entries));
+    }
+  }
+
+  findBySupplier(code: string): CatalogEntry | undefined {
+    return this.entries.find(e => e.supplierCodes.includes(code));
+  }
+
+  findByName(name: string, brand?: string): CatalogEntry | undefined {
+    const target = normalise(`${brand ?? ''} ${name}`);
+    let best: { entry: CatalogEntry; score: number } | undefined;
+    for (const entry of this.entries) {
+      const candidate = normalise(`${entry.brand ?? ''} ${entry.name}`);
+      const score = similarity(target, candidate);
+      if (score > 0.8 && (!best || score > best.score)) {
+        best = { entry, score };
+      }
+    }
+    return best?.entry;
+  }
+
+  add(entry: CatalogEntry): void {
+    this.entries.push(entry);
+    this.persist();
+  }
+
+  mapSupplier(code: string, entry: CatalogEntry): void {
+    if (!entry.supplierCodes.includes(code)) {
+      entry.supplierCodes.push(code);
+      this.persist();
+    }
+  }
+
+  relink(from: string, to: string): void {
+    for (const entry of this.entries) {
+      if (entry.itemCode === from) entry.itemCode = to;
+      entry.supplierCodes = entry.supplierCodes.map(c => (c === from ? to : c));
+    }
+    this.persist();
+  }
+
+  disable(itemCode: string): void {
+    const entry = this.entries.find(e => e.itemCode === itemCode);
+    if (entry) {
+      entry.disabled = true;
+      this.persist();
+    }
+  }
+}
+
+const catalog = new CatalogMap();
+
+export async function resolveOrCreateItem(data: ResolverInput): Promise<string> {
+  if (data.supplierCode) {
+    const bySupplier = catalog.findBySupplier(data.supplierCode);
+    if (bySupplier) return bySupplier.itemCode;
+  }
+
+  const byName = catalog.findByName(data.name, data.brand);
+  if (byName) {
+    if (data.supplierCode) catalog.mapSupplier(data.supplierCode, byName);
+    return byName.itemCode;
+  }
+
+  const now = new Date();
+  const yymm = now.toISOString().slice(0, 7).replace('-', '');
+  const hash = crypto
+    .createHash('md5')
+    .update(`${data.supplierCode || ''}|${data.name}|${data.brand || ''}|${now.getTime()}`)
+    .digest('hex')
+    .slice(0, 6);
+  const itemCode = `TMP-${yymm}-${hash}`;
+  const entry: CatalogEntry = {
+    itemCode,
+    supplierCodes: data.supplierCode ? [data.supplierCode] : [],
+    name: data.name,
+    brand: data.brand,
+    provisional: true,
+  };
+  catalog.add(entry);
+  return itemCode;
+}
+
+export function mergeItems(from: string, to: string): void {
+  catalog.relink(from, to);
+  catalog.disable(from);
+}
+
+export { CatalogMap, catalog as CatalogMapInstance };
+


### PR DESCRIPTION
## Summary
- add SKU resolver service with fuzzy matching and provisional TMP codes
- integrate resolver into invoice and stock mappers

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck` (fails: left-hand side of an 'instanceof' expression...)


------
https://chatgpt.com/codex/tasks/task_e_68ae30898c908323bc7db5f2e3c6c168