### PR TITLE
feat: import bank transactions

### DIFF
--- a/src/app/api/erpnext/bank/route.ts
+++ b/src/app/api/erpnext/bank/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import type { BankTransaction } from '@/lib/erpnext/types';
+import { parseBankCSV, toBankTransactions } from '@/csv/parsers';
+import { upsertBankTransactions, applyMatchingRules } from '@/lib/erpnext/services/bank';
+import type { ERPIncomingInvoiceItem } from '@/types/incoming-invoice';
+
+export async function POST(request: Request) {
+  if (!process.env.ERNEXT_BANK_TRANSACTION_URL || !process.env.ERNEXT_API_KEY || !process.env.ERNEXT_API_SECRET) {
+    return NextResponse.json(
+      { error: 'Server configuration error: ERPNext credentials not set.' },
+      { status: 500 },
+    );
+  }
+
+  const headers = {
+    Authorization: `token ${process.env.ERNEXT_API_KEY}:${process.env.ERNEXT_API_SECRET}`,
+    Accept: 'application/json',
+  };
+
+  let transactions: BankTransaction[] = [];
+  const contentType = request.headers.get('content-type') || '';
+
+  try {
+    if (contentType.includes('text/csv')) {
+      const csv = await request.text();
+      const rows = parseBankCSV(csv);
+      const account = process.env.ERNEXT_BANK_ACCOUNT || '';
+      transactions = toBankTransactions(rows, account);
+    } else {
+      const body = await request.json();
+      transactions = (body.transactions || []) as BankTransaction[];
+      if (body.invoices) {
+        await applyMatchingRules(
+          transactions,
+          body.invoices as ERPIncomingInvoiceItem[],
+          {
+            endpoint: process.env.ERNEXT_BANK_TRANSACTION_URL!,
+            paymentEndpoint: process.env.ERNEXT_PAYMENT_ENTRY_URL,
+            headers,
+            createPayments: true,
+          },
+        );
+      }
+    }
+
+    if (transactions.length === 0) {
+      return NextResponse.json({ error: 'No transactions provided.' }, { status: 400 });
+    }
+
+    await upsertBankTransactions(transactions, {
+      endpoint: process.env.ERNEXT_BANK_TRANSACTION_URL!,
+      headers,
+    });
+
+    return NextResponse.json({ message: `${transactions.length} transaction(s) processed.` });
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message || 'Failed to process transactions.' }, { status: 500 });
+  }
+}

--- a/src/csv/parsers.ts
+++ b/src/csv/parsers.ts
@@ -1,0 +1,68 @@
+import Papa from 'papaparse';
+import { z } from 'zod';
+import type { BankTransaction } from '@/lib/erpnext/types';
+
+// Schema describing a generic bank CSV row. The parser is liberal in
+// accepting column names by mapping common variants to this shape.
+const BankCsvRowSchema = z.object({
+  date: z.string(),
+  description: z.string().optional(),
+  amount: z.string(),
+  reference_number: z.string().optional(),
+});
+export type BankCsvRow = z.infer<typeof BankCsvRowSchema>;
+
+/**
+ * Parse a CSV string containing bank transactions. The parser accepts a
+ * header row and will skip empty lines. Column names are matched in a
+ * case-insensitive manner and support common aliases such as
+ * "Datum", "Betrag" etc.
+ */
+export function parseBankCSV(csv: string): BankCsvRow[] {
+  const parsed = Papa.parse<Record<string, string>>(csv, {
+    header: true,
+    skipEmptyLines: true,
+  });
+  const rows: BankCsvRow[] = [];
+  for (const raw of parsed.data) {
+    const row = BankCsvRowSchema.safeParse({
+      date: raw.date || raw.Date || raw.Datum,
+      description:
+        raw.description ||
+        raw.Description ||
+        raw.Buchungstext ||
+        raw.Verwendungszweck,
+      amount: raw.amount || raw.Amount || raw.Betrag,
+      reference_number: raw.reference_number || raw.Reference || raw.Ref,
+    });
+    if (row.success) rows.push(row.data);
+  }
+  return rows;
+}
+
+// Helper to normalise European number formats (e.g. "1.234,56")
+function parseAmount(str: string): number {
+  const cleaned = str.replace(/\./g, '').replace(/,/g, '.').trim();
+  const num = Number(cleaned);
+  return Number.isNaN(num) ? 0 : num;
+}
+
+/**
+ * Convert parsed CSV rows into ERPNext Bank Transaction payloads. The bank
+ * account is supplied externally because it is installation specific.
+ */
+export function toBankTransactions(rows: BankCsvRow[], account: string): BankTransaction[] {
+  return rows.map(row => {
+    const amount = parseAmount(row.amount);
+    return {
+      doctype: 'Bank Transaction',
+      date: row.date,
+      account,
+      description: row.description,
+      reference_number: row.reference_number,
+      deposit: amount > 0 ? amount : undefined,
+      withdrawal: amount < 0 ? -amount : undefined,
+    };
+  });
+}
+

--- a/src/lib/erpnext/services/bank.ts
+++ b/src/lib/erpnext/services/bank.ts
@@ -1,0 +1,99 @@
+import crypto from 'crypto';
+import type { BankTransaction, PaymentEntry } from '../types';
+import type { ERPIncomingInvoiceItem } from '@/types/incoming-invoice';
+import { parseBankCSV, toBankTransactions } from '@/csv/parsers';
+import { matchTransactions } from '@/lib/bank-matcher/matchBankToInvoices';
+import { findExistingBankTransaction } from './dedupe';
+
+/** Parse CSV text into ERPNext Bank Transaction payloads. */
+export function parseCsvLines(csv: string, account: string): BankTransaction[] {
+  const rows = parseBankCSV(csv);
+  return toBankTransactions(rows, account);
+}
+
+function idempotencyKey(tx: BankTransaction): string {
+  const amount = tx.deposit ?? (tx.withdrawal ? -tx.withdrawal : 0);
+  const refHash = crypto
+    .createHash('sha256')
+    .update(tx.reference_number || '')
+    .digest('hex')
+    .slice(0, 8);
+  return `bank:${tx.date}:${amount.toFixed(2)}:${refHash}`;
+}
+
+interface Options {
+  endpoint: string;
+  headers?: Record<string, string>;
+}
+
+/**
+ * Upsert a set of bank transactions into ERPNext using idempotency keys to
+ * avoid duplicates. Returns the keys of newly created transactions.
+ */
+export async function upsertBankTransactions(
+  transactions: BankTransaction[],
+  options: Options,
+): Promise<string[]> {
+  const created: string[] = [];
+  for (const tx of transactions) {
+    const existing = await findExistingBankTransaction(tx, options);
+    if (existing) continue;
+    const key = idempotencyKey(tx);
+    await fetch(options.endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+      body: JSON.stringify({ ...tx, idempotency_key: key }),
+    });
+    created.push(key);
+  }
+  return created;
+}
+
+/**
+ * Apply matching rules between bank transactions and provided invoices. When
+ * `createPayments` is true, Payment Entries will be created in ERPNext for
+ * transactions confidently matched to an invoice.
+ */
+export async function applyMatchingRules(
+  transactions: BankTransaction[],
+  invoices: ERPIncomingInvoiceItem[],
+  options: Options & { paymentEndpoint?: string; createPayments?: boolean },
+) {
+  const matches = await matchTransactions(transactions, invoices);
+  if (options.createPayments && options.paymentEndpoint) {
+    for (const m of matches) {
+      if (m.matchedInvoice && m.status === 'Matched') {
+        const amount = Math.abs(
+          m.transaction.deposit ?? -(m.transaction.withdrawal || 0),
+        );
+        const entry: PaymentEntry = {
+          doctype: 'Payment Entry',
+          payment_type: 'Pay',
+          posting_date: m.transaction.date,
+          party_type: 'Supplier',
+          party: m.matchedInvoice.lieferantName,
+          paid_from: m.transaction.account,
+          paid_amount: amount,
+          references: [
+            {
+              reference_doctype: 'Purchase Invoice',
+              reference_name: m.matchedInvoice.rechnungsnummer,
+              allocated_amount: amount,
+            },
+          ],
+        };
+        await fetch(options.paymentEndpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(options.headers || {}),
+          },
+          body: JSON.stringify(entry),
+        });
+      }
+    }
+  }
+  return matches;
+}
+
+export { idempotencyKey };


### PR DESCRIPTION
## Summary
- add generic bank CSV parser and service to upsert transactions with idempotency
- support matching bank transactions to invoices with optional payment entries
- expose `/api/erpnext/bank` route that accepts CSV or JSON

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck` *(fails: type errors in unrelated files)*


------
https://chatgpt.com/codex/tasks/task_e_68ae4691b9308323b04a3e80749b097e