### PR TITLE
feat: add ERPNext stock endpoints with idempotency

### DIFF
--- a/src/app/api/erpnext/stock/route.ts
+++ b/src/app/api/erpnext/stock/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import type { StockReconciliation, StockEntry } from '@/lib/erpnext/types';
+import { createStockReconciliation, createStockEntry } from '@/lib/erpnext/services/stock';
+
+export async function POST(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const type = searchParams.get('type');
+
+  if (!process.env.ERNEXT_API_KEY || !process.env.ERNEXT_API_SECRET) {
+    return NextResponse.json(
+      { error: 'Server configuration error: ERPNext credentials not set.' },
+      { status: 500 },
+    );
+  }
+
+  const headers = {
+    Authorization: `token ${process.env.ERNEXT_API_KEY}:${process.env.ERNEXT_API_SECRET}`,
+    Accept: 'application/json',
+  };
+
+  try {
+    const body = await request.json();
+
+    if (type === 'reconciliation') {
+      if (!process.env.ERNEXT_STOCK_RECONCILIATION_URL) {
+        return NextResponse.json(
+          { error: 'Server configuration error: Stock Reconciliation URL not set.' },
+          { status: 500 },
+        );
+      }
+      await createStockReconciliation(body as StockReconciliation, {
+        endpoint: process.env.ERNEXT_STOCK_RECONCILIATION_URL!,
+        headers,
+      });
+      return NextResponse.json({ message: 'Stock reconciliation processed.' });
+    }
+
+    if (type === 'entry') {
+      if (!process.env.ERNEXT_STOCK_ENTRY_URL) {
+        return NextResponse.json(
+          { error: 'Server configuration error: Stock Entry URL not set.' },
+          { status: 500 },
+        );
+      }
+      await createStockEntry(body as StockEntry, {
+        endpoint: process.env.ERNEXT_STOCK_ENTRY_URL!,
+        headers,
+      });
+      return NextResponse.json({ message: 'Stock entry processed.' });
+    }
+
+    return NextResponse.json({ error: 'Invalid type parameter.' }, { status: 400 });
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e.message || 'Failed to process stock document.' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/erpnext/services/stock.ts
+++ b/src/lib/erpnext/services/stock.ts
@@ -1,0 +1,46 @@
+import type { StockReconciliation, StockEntry } from '../types';
+
+interface Options {
+  endpoint: string;
+  headers?: Record<string, string>;
+}
+
+function buildKey(
+  type: 'reconciliation' | 'entry',
+  warehouse: string,
+  itemCode: string,
+  postingDate: string,
+): string {
+  return `stock:${type}:${warehouse}:${itemCode}:${postingDate}`;
+}
+
+export async function createStockReconciliation(
+  doc: StockReconciliation,
+  options: Options,
+): Promise<string> {
+  const item = doc.items[0];
+  const key = buildKey('reconciliation', item.warehouse, item.item_code, doc.posting_date);
+  await fetch(options.endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    body: JSON.stringify({ ...doc, idempotency_key: key }),
+  });
+  return key;
+}
+
+export async function createStockEntry(
+  doc: StockEntry,
+  options: Options,
+): Promise<string> {
+  const item = doc.items[0];
+  const warehouse = item.s_warehouse || item.t_warehouse || '';
+  const key = buildKey('entry', warehouse, item.item_code, doc.posting_date);
+  await fetch(options.endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    body: JSON.stringify({ ...doc, idempotency_key: key }),
+  });
+  return key;
+}
+
+export { buildKey as stockKey };


### PR DESCRIPTION
## Summary
- add stock service functions for reconciliation and entry with idempotent keys
- expose API route for stock operations via type param

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive ESLint setup prompt)*
- `npm run typecheck` *(fails: left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter)*

------
https://chatgpt.com/codex/tasks/task_e_68aec361c024832393fc05b7e688a8dc