### PR TITLE
feat: add ERPNext stock service and API

### DIFF
--- a/src/app/api/erpnext/stock/route.ts
+++ b/src/app/api/erpnext/stock/route.ts
@@ -28,11 +28,11 @@ export async function POST(request: Request) {
           { status: 500 },
         );
       }
-      await createStockReconciliation(body as StockReconciliation, {
+      const key = await createStockReconciliation(body as StockReconciliation, {
         endpoint: process.env.ERNEXT_STOCK_RECONCILIATION_URL!,
         headers,
       });
-      return NextResponse.json({ message: 'Stock reconciliation processed.' });
+      return NextResponse.json({ message: 'Stock reconciliation processed.', key });
     }
 
     if (type === 'entry') {
@@ -42,11 +42,11 @@ export async function POST(request: Request) {
           { status: 500 },
         );
       }
-      await createStockEntry(body as StockEntry, {
+      const key = await createStockEntry(body as StockEntry, {
         endpoint: process.env.ERNEXT_STOCK_ENTRY_URL!,
         headers,
       });
-      return NextResponse.json({ message: 'Stock entry processed.' });
+      return NextResponse.json({ message: 'Stock entry processed.', key });
     }
 
     return NextResponse.json({ error: 'Invalid type parameter.' }, { status: 400 });

--- a/src/lib/erpnext/services/stock.ts
+++ b/src/lib/erpnext/services/stock.ts
@@ -5,8 +5,14 @@ interface Options {
   headers?: Record<string, string>;
 }
 
-function buildKey(
-  type: 'reconciliation' | 'entry',
+type StockDocType = 'reconciliation' | 'entry';
+
+/**
+ * Build the idempotency key used for stock operations.
+ * The format is: `stock:{type}:{warehouse}:{item_code}:{posting_date}`
+ */
+export function stockKey(
+  type: StockDocType,
   warehouse: string,
   itemCode: string,
   postingDate: string,
@@ -14,17 +20,25 @@ function buildKey(
   return `stock:${type}:${warehouse}:${itemCode}:${postingDate}`;
 }
 
-export async function createStockReconciliation(
-  doc: StockReconciliation,
+async function postStockDocument(
+  doc: StockReconciliation | StockEntry,
+  key: string,
   options: Options,
-): Promise<string> {
-  const item = doc.items[0];
-  const key = buildKey('reconciliation', item.warehouse, item.item_code, doc.posting_date);
+): Promise<void> {
   await fetch(options.endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
     body: JSON.stringify({ ...doc, idempotency_key: key }),
   });
+}
+
+export async function createStockReconciliation(
+  doc: StockReconciliation,
+  options: Options,
+): Promise<string> {
+  const item = doc.items[0];
+  const key = stockKey('reconciliation', item.warehouse, item.item_code, doc.posting_date);
+  await postStockDocument(doc, key, options);
   return key;
 }
 
@@ -34,13 +48,7 @@ export async function createStockEntry(
 ): Promise<string> {
   const item = doc.items[0];
   const warehouse = item.s_warehouse || item.t_warehouse || '';
-  const key = buildKey('entry', warehouse, item.item_code, doc.posting_date);
-  await fetch(options.endpoint, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
-    body: JSON.stringify({ ...doc, idempotency_key: key }),
-  });
+  const key = stockKey('entry', warehouse, item.item_code, doc.posting_date);
+  await postStockDocument(doc, key, options);
   return key;
 }
-
-export { buildKey as stockKey };


### PR DESCRIPTION
## Summary
- add stock service functions with idempotent keys
- expose API route to create stock reconciliation or entry documents

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*
- `npm run typecheck` *(fails: TS errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68aee348712083239b55c82ff2c282b8