### PR TITLE
feat: add CSV writers and mode toggle

### DIFF
--- a/src/lib/csv/writers.ts
+++ b/src/lib/csv/writers.ts
@@ -1,0 +1,86 @@
+import type { BankTransaction as InternalBankTransaction } from '@/lib/bank-matcher/types';
+import type { ERPIncomingInvoiceItem } from '@/types/incoming-invoice';
+import { mapBankTransaction } from '../erpnext/mappers/bank';
+import { mapPurchaseInvoice } from '../erpnext/mappers/invoice';
+import { mapItem, type InternalItem } from '../erpnext/mappers/item';
+import {
+  mapStockEntry,
+  mapStockReconciliation,
+  type InternalStockEntry,
+  type InternalStockReconciliation,
+} from '../erpnext/mappers/stock';
+
+/** Determine if the pipeline should emit CSV rows instead of performing API calls. */
+function isCsvMode(): boolean {
+  return (process.env.FINANCIO_MODE || 'api') === 'csv';
+}
+
+/**
+ * Convert internal bank transactions to CSV rows using the existing mapper.
+ */
+export async function bankTransactionsToCsv(
+  transactions: InternalBankTransaction[],
+): Promise<string> {
+  const rows: string[] = [];
+  for (const tx of transactions) {
+    const { csv } = await mapBankTransaction(tx, { dryRun: true });
+    rows.push(csv);
+  }
+  return rows.join('\n');
+}
+
+/**
+ * Convert purchase invoices to CSV rows using the existing mapper.
+ */
+export async function purchaseInvoicesToCsv(
+  invoices: ERPIncomingInvoiceItem[],
+): Promise<string> {
+  const rows: string[] = [];
+  for (const invoice of invoices) {
+    const { csv } = await mapPurchaseInvoice(invoice, { dryRun: true });
+    if (csv) rows.push(csv);
+  }
+  return rows.join('\n');
+}
+
+/**
+ * Convert items to CSV rows using the existing mapper.
+ */
+export async function itemsToCsv(items: InternalItem[]): Promise<string> {
+  const rows: string[] = [];
+  for (const item of items) {
+    const { csv } = await mapItem(item, { dryRun: true });
+    rows.push(csv);
+  }
+  return rows.join('\n');
+}
+
+/**
+ * Convert stock reconciliations to CSV rows using the existing mapper.
+ */
+export async function stockReconciliationsToCsv(
+  stocks: InternalStockReconciliation[],
+): Promise<string> {
+  const rows: string[] = [];
+  for (const stock of stocks) {
+    const { csv } = await mapStockReconciliation(stock, { dryRun: true });
+    if (csv) rows.push(csv);
+  }
+  return rows.join('\n');
+}
+
+/**
+ * Convert stock entries to CSV rows using the existing mapper.
+ */
+export async function stockEntriesToCsv(
+  entries: InternalStockEntry[],
+): Promise<string> {
+  const rows: string[] = [];
+  for (const entry of entries) {
+    const { csv } = await mapStockEntry(entry, { dryRun: true });
+    if (csv) rows.push(csv);
+  }
+  return rows.join('\n');
+}
+
+export { isCsvMode };

--- a/src/lib/erpnext/mappers/bank.ts
+++ b/src/lib/erpnext/mappers/bank.ts
@@ -8,6 +8,11 @@ interface MapperOptions {
   headers?: Record<string, string>;
 }
 
+function shouldPost(options: MapperOptions): boolean {
+  const mode = process.env.FINANCIO_MODE || 'api';
+  return mode === 'api' && !options.dryRun && Boolean(options.endpoint);
+}
+
 function escapeCSVField(field: string | number | undefined | null): string {
   if (field === undefined || field === null) return '';
   const stringField = String(field);
@@ -42,16 +47,16 @@ export async function mapBankTransaction(
     tx.currency || 'EUR',
   ].map(escapeCSVField).join(',');
 
-  if (!options.dryRun && options.endpoint) {
+  if (shouldPost(options)) {
     const existing = await findExistingBankTransaction(payload, {
-      endpoint: options.endpoint,
+      endpoint: options.endpoint!,
       headers: options.headers,
     });
     if (existing) {
       return { payload, csv, response: { duplicate: true, existing } };
     }
 
-    const response = await fetch(options.endpoint, {
+    const response = await fetch(options.endpoint!, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/lib/erpnext/mappers/invoice.ts
+++ b/src/lib/erpnext/mappers/invoice.ts
@@ -12,6 +12,11 @@ interface MapperOptions {
   headers?: Record<string, string>;
 }
 
+function shouldPost(options: MapperOptions): boolean {
+  const mode = process.env.FINANCIO_MODE || 'api';
+  return mode === 'api' && !options.dryRun && Boolean(options.endpoint);
+}
+
 function escapeCSVField(field: string | number | undefined | null): string {
   if (field === undefined || field === null) return '';
   const stringField = String(field);
@@ -82,9 +87,9 @@ export async function mapPurchaseInvoice(
     csvRows.push(invoiceData.join(','));
   }
 
-  if (!options.dryRun && options.endpoint) {
+  if (shouldPost(options)) {
     const existing = await findExistingPurchaseInvoice(payload, {
-      endpoint: options.endpoint,
+      endpoint: options.endpoint!,
       headers: options.headers,
     });
     if (existing) {
@@ -95,7 +100,7 @@ export async function mapPurchaseInvoice(
       };
     }
 
-    const response = await fetch(options.endpoint, {
+    const response = await fetch(options.endpoint!, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/lib/erpnext/mappers/item.ts
+++ b/src/lib/erpnext/mappers/item.ts
@@ -16,6 +16,11 @@ interface MapperOptions {
   headers?: Record<string, string>;
 }
 
+function shouldPost(options: MapperOptions): boolean {
+  const mode = process.env.FINANCIO_MODE || 'api';
+  return mode === 'api' && !options.dryRun && Boolean(options.endpoint);
+}
+
 function escapeCSVField(field: string | number | undefined | null): string {
   if (field === undefined || field === null) return '';
   const stringField = String(field);
@@ -47,16 +52,16 @@ export async function mapItem(
     item.isStockItem ? 1 : 0,
   ].map(escapeCSVField).join(',');
 
-  if (!options.dryRun && options.endpoint) {
+  if (shouldPost(options)) {
     const existing = await findExistingItem(payload, {
-      endpoint: options.endpoint,
+      endpoint: options.endpoint!,
       headers: options.headers,
     });
     if (existing) {
       return { payload, csv, response: { duplicate: true, existing } };
     }
 
-    const response = await fetch(options.endpoint, {
+    const response = await fetch(options.endpoint!, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/lib/erpnext/mappers/stock.ts
+++ b/src/lib/erpnext/mappers/stock.ts
@@ -33,6 +33,11 @@ interface MapperOptions {
   headers?: Record<string, string>;
 }
 
+function shouldPost(options: MapperOptions): boolean {
+  const mode = process.env.FINANCIO_MODE || 'api';
+  return mode === 'api' && !options.dryRun && Boolean(options.endpoint);
+}
+
 function escapeCSVField(field: string | number | undefined | null): string {
   if (field === undefined || field === null) return '';
   const stringField = String(field);
@@ -79,7 +84,7 @@ function escapeCSVField(field: string | number | undefined | null): string {
       it.valuationRate ?? '',
     ].map(escapeCSVField).join(','));
 
-  if (!options.dryRun && options.endpoint) {
+  if (shouldPost(options)) {
     if (isDuplicateStockReconciliation(payload)) {
       return {
         payload,
@@ -88,7 +93,7 @@ function escapeCSVField(field: string | number | undefined | null): string {
       };
     }
 
-    const response = await fetch(options.endpoint, {
+    const response = await fetch(options.endpoint!, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -147,7 +152,7 @@ export async function mapStockEntry(
     it.basicRate ?? '',
   ].map(escapeCSVField).join(','));
 
-  if (!options.dryRun && options.endpoint) {
+  if (shouldPost(options)) {
     if (isDuplicateStockEntry(payload)) {
       return {
         payload,
@@ -156,7 +161,7 @@ export async function mapStockEntry(
       };
     }
 
-    const response = await fetch(options.endpoint, {
+      const response = await fetch(options.endpoint!, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- add csv writer utilities using existing ERPNext mappers
- respect FINANCIO_MODE to disable API calls in mappers

## Testing
- `npm run lint` *(fails: prompts for eslint configuration)*
- `npm run typecheck` *(fails: type errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68afa8a37ac88323b324a5df0f283860