### PR TITLE
feat: add ERPNext invoice and item routes

### DIFF
--- a/src/app/api/csv/export/route.ts
+++ b/src/app/api/csv/export/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import {
+  bankTransactionsToCsv,
+  purchaseInvoicesToCsv,
+  itemsToCsv,
+  stockReconciliationsToCsv,
+  stockEntriesToCsv,
+} from '@/lib/csv/writers';
+
+export async function POST(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const type = searchParams.get('type');
+
+  if (!type) {
+    return NextResponse.json({ error: 'Missing type parameter.' }, { status: 400 });
+  }
+
+  try {
+    const body = await request.json();
+    let csv = '';
+
+    switch (type) {
+      case 'bank':
+        csv = await bankTransactionsToCsv(body.transactions || []);
+        break;
+      case 'invoice':
+      case 'purchase':
+        csv = await purchaseInvoicesToCsv(body.invoices || []);
+        break;
+      case 'item':
+        csv = await itemsToCsv(body.items || []);
+        break;
+      case 'stock-reconciliation':
+        csv = await stockReconciliationsToCsv(body.stocks || body.reconciliations || []);
+        break;
+      case 'stock-entry':
+        csv = await stockEntriesToCsv(body.entries || []);
+        break;
+      default:
+        return NextResponse.json({ error: 'Invalid type parameter.' }, { status: 400 });
+    }
+
+    return new Response(csv, {
+      headers: { 'Content-Type': 'text/csv' },
+    });
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e.message || 'Failed to generate CSV.' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/erpnext/bank/route.ts
+++ b/src/app/api/erpnext/bank/route.ts
@@ -1,21 +1,27 @@
 import { NextResponse } from 'next/server';
 import type { BankTransaction } from '@/lib/erpnext/types';
-import { parseBankCSV, toBankTransactions } from '@/csv/parsers';
-import { upsertBankTransactions, applyMatchingRules } from '@/lib/erpnext/services/bank';
+import { parseCsvLines, upsertBankTransactions, applyMatchingRules } from '@/lib/erpnext/services/bank';
 import type { ERPIncomingInvoiceItem } from '@/types/incoming-invoice';
 
 export async function POST(request: Request) {
-  if (!process.env.ERNEXT_BANK_TRANSACTION_URL || !process.env.ERNEXT_API_KEY || !process.env.ERNEXT_API_SECRET) {
-    return NextResponse.json(
-      { error: 'Server configuration error: ERPNext credentials not set.' },
-      { status: 500 },
-    );
+  const { searchParams } = new URL(request.url);
+  const dryRun = searchParams.get('dryRun') === 'true';
+
+  if (!dryRun) {
+    if (!process.env.ERNEXT_BANK_TRANSACTION_URL || !process.env.ERNEXT_API_KEY || !process.env.ERNEXT_API_SECRET) {
+      return NextResponse.json(
+        { error: 'Server configuration error: ERPNext credentials not set.' },
+        { status: 500 },
+      );
+    }
   }
 
-  const headers = {
-    Authorization: `token ${process.env.ERNEXT_API_KEY}:${process.env.ERNEXT_API_SECRET}`,
-    Accept: 'application/json',
-  };
+  const headers = !dryRun
+    ? {
+        Authorization: `token ${process.env.ERNEXT_API_KEY}:${process.env.ERNEXT_API_SECRET}`,
+        Accept: 'application/json',
+      }
+    : undefined;
 
   let transactions: BankTransaction[] = [];
   const contentType = request.headers.get('content-type') || '';
@@ -23,13 +29,12 @@ export async function POST(request: Request) {
   try {
     if (contentType.includes('text/csv')) {
       const csv = await request.text();
-      const rows = parseBankCSV(csv);
       const account = process.env.ERNEXT_BANK_ACCOUNT || '';
-      transactions = toBankTransactions(rows, account);
+      transactions = parseCsvLines(csv, account);
     } else {
       const body = await request.json();
       transactions = (body.transactions || []) as BankTransaction[];
-      if (body.invoices) {
+      if (!dryRun && body.invoices) {
         await applyMatchingRules(
           transactions,
           body.invoices as ERPIncomingInvoiceItem[],
@@ -47,10 +52,12 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'No transactions provided.' }, { status: 400 });
     }
 
-    await upsertBankTransactions(transactions, {
-      endpoint: process.env.ERNEXT_BANK_TRANSACTION_URL!,
-      headers,
-    });
+    if (!dryRun) {
+      await upsertBankTransactions(transactions, {
+        endpoint: process.env.ERNEXT_BANK_TRANSACTION_URL!,
+        headers,
+      });
+    }
 
     return NextResponse.json({ message: `${transactions.length} transaction(s) processed.` });
   } catch (e: any) {

--- a/src/app/api/erpnext/invoices/route.ts
+++ b/src/app/api/erpnext/invoices/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import type { ERPIncomingInvoiceItem } from '@/types/incoming-invoice';
+import { mapPurchaseInvoice } from '@/lib/erpnext/mappers/invoice';
+
+export async function POST(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const type = searchParams.get('type') || 'purchase';
+  const mode = searchParams.get('mode') || 'api';
+  const dryRun = searchParams.get('dryRun') === 'true' || mode === 'csv';
+
+  if (type !== 'purchase' && type !== 'sales') {
+    return NextResponse.json({ error: 'Invalid type parameter.' }, { status: 400 });
+  }
+
+  if (type === 'sales') {
+    return NextResponse.json({ error: 'Sales invoices are not supported yet.' }, { status: 501 });
+  }
+
+  if (mode === 'api' && !dryRun) {
+    if (!process.env.ERNEXT_PURCHASE_INVOICE_URL || !process.env.ERNEXT_API_KEY || !process.env.ERNEXT_API_SECRET) {
+      return NextResponse.json(
+        { error: 'Server configuration error: ERPNext credentials not set.' },
+        { status: 500 },
+      );
+    }
+  }
+
+  const headers =
+    mode === 'api' && !dryRun
+      ? {
+          Authorization: `token ${process.env.ERNEXT_API_KEY}:${process.env.ERNEXT_API_SECRET}`,
+          Accept: 'application/json',
+        }
+      : undefined;
+
+  try {
+    const { invoices } = (await request.json()) as { invoices: ERPIncomingInvoiceItem[] };
+    const rows: string[] = [];
+    for (const invoice of invoices) {
+      const { csv } = await mapPurchaseInvoice(invoice, {
+        endpoint: mode === 'api' && !dryRun ? process.env.ERNEXT_PURCHASE_INVOICE_URL : undefined,
+        headers,
+        dryRun,
+      });
+      if (csv) rows.push(csv);
+    }
+
+    if (mode === 'csv') {
+      return new Response(rows.join('\n'), {
+        headers: { 'Content-Type': 'text/csv' },
+      });
+    }
+
+    return NextResponse.json({ message: `${invoices.length} invoice(s) processed.` });
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e.message || 'Failed to process invoices.' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/erpnext/items/route.ts
+++ b/src/app/api/erpnext/items/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+import { mapItem, type InternalItem } from '@/lib/erpnext/mappers/item';
+import { mergeItems } from '@/lib/erpnext/services/sku-resolver';
+
+export async function POST(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const mode = searchParams.get('mode') || 'api';
+  const dryRun = searchParams.get('dryRun') === 'true' || mode === 'csv';
+
+  if (mode === 'api' && !dryRun) {
+    if (!process.env.ERNEXT_ITEM_URL || !process.env.ERNEXT_API_KEY || !process.env.ERNEXT_API_SECRET) {
+      return NextResponse.json(
+        { error: 'Server configuration error: ERPNext credentials not set.' },
+        { status: 500 },
+      );
+    }
+  }
+
+  const headers =
+    mode === 'api' && !dryRun
+      ? {
+          Authorization: `token ${process.env.ERNEXT_API_KEY}:${process.env.ERNEXT_API_SECRET}`,
+          Accept: 'application/json',
+        }
+      : undefined;
+
+  try {
+    const { items = [], merges = [] } = (await request.json()) as {
+      items?: InternalItem[];
+      merges?: { from: string; to: string }[];
+    };
+
+    for (const m of merges) {
+      mergeItems(m.from, m.to);
+    }
+
+    const rows: string[] = [];
+    for (const item of items) {
+      const { csv } = await mapItem(item, {
+        endpoint: mode === 'api' && !dryRun ? process.env.ERNEXT_ITEM_URL : undefined,
+        headers,
+        dryRun,
+      });
+      if (csv) rows.push(csv);
+    }
+
+    if (mode === 'csv') {
+      return new Response(rows.join('\n'), {
+        headers: { 'Content-Type': 'text/csv' },
+      });
+    }
+
+    return NextResponse.json({ message: `${items.length} item(s) processed.`, merges: merges.length });
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e.message || 'Failed to process items.' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/erpnext/stock/route.ts
+++ b/src/app/api/erpnext/stock/route.ts
@@ -5,23 +5,31 @@ import { createStockReconciliation, createStockEntry } from '@/lib/erpnext/servi
 export async function POST(request: Request) {
   const { searchParams } = new URL(request.url);
   const type = searchParams.get('type');
+  const dryRun = searchParams.get('dryRun') === 'true';
 
-  if (!process.env.ERNEXT_API_KEY || !process.env.ERNEXT_API_SECRET) {
-    return NextResponse.json(
-      { error: 'Server configuration error: ERPNext credentials not set.' },
-      { status: 500 },
-    );
+  if (!dryRun) {
+    if (!process.env.ERNEXT_API_KEY || !process.env.ERNEXT_API_SECRET) {
+      return NextResponse.json(
+        { error: 'Server configuration error: ERPNext credentials not set.' },
+        { status: 500 },
+      );
+    }
   }
 
-  const headers = {
-    Authorization: `token ${process.env.ERNEXT_API_KEY}:${process.env.ERNEXT_API_SECRET}`,
-    Accept: 'application/json',
-  };
+  const headers = !dryRun
+    ? {
+        Authorization: `token ${process.env.ERNEXT_API_KEY}:${process.env.ERNEXT_API_SECRET}`,
+        Accept: 'application/json',
+      }
+    : undefined;
 
   try {
     const body = await request.json();
 
     if (type === 'reconciliation') {
+      if (dryRun) {
+        return NextResponse.json({ message: 'Dry run: reconciliation skipped.' });
+      }
       if (!process.env.ERNEXT_STOCK_RECONCILIATION_URL) {
         return NextResponse.json(
           { error: 'Server configuration error: Stock Reconciliation URL not set.' },
@@ -36,6 +44,9 @@ export async function POST(request: Request) {
     }
 
     if (type === 'entry') {
+      if (dryRun) {
+        return NextResponse.json({ message: 'Dry run: entry skipped.' });
+      }
       if (!process.env.ERNEXT_STOCK_ENTRY_URL) {
         return NextResponse.json(
           { error: 'Server configuration error: Stock Entry URL not set.' },


### PR DESCRIPTION
## Summary
- add ERPNext invoice and item API routes with dry-run and CSV support
- extend bank and stock routes to honour dry-run and service helpers
- provide generic CSV export route for multiple document types

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive configuration)
- `npm run typecheck` (fails: TS errors in existing files)


------
https://chatgpt.com/codex/tasks/task_e_68afaf7a2ce48323a4701aff006cd700